### PR TITLE
Feature/rotate air holes for printing

### DIFF
--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -7,6 +7,7 @@ switch_depth = 135.0;
 switch_height = 28.30;
 
 case_thickness = 6; // Thickness of case walls
+wire_diameter = 7; // Diameter of power wire holes
 
 front_wire_holes = false; // [true:Show front wire holes, false:Hide front wire holes]
 air_holes = true; // [true:Show air holes, false:Hide air holes]
@@ -157,18 +158,17 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         }
     }
 
-    // Power wire cutouts: 5mm diameter holes at top and bottom rack hole positions
+    // Power wire cutouts: configurable diameter holes at top and bottom rack hole positions
     module power_wire_cutouts() {
         hole_spacing_x = switch_width; // match rack holes
-        hole_diameter = 7;
-        hole_left_x = (rack_width - hole_spacing_x) / 2 - (hole_diameter /5);
-        hole_right_x = (rack_width + hole_spacing_x) / 2 + (hole_diameter /5);
+        hole_left_x = (rack_width - hole_spacing_x) / 2 - (wire_diameter /5);
+        hole_right_x = (rack_width + hole_spacing_x) / 2 + (wire_diameter /5);
         // Midplane of switch opening
         mid_y = (height - switch_height) / 2 + switch_height / 2;
         for (side_x = [hole_left_x, hole_right_x]) {
             translate([side_x, mid_y, 0]) {
                 linear_extrude(height = chassis_depth_main) {
-                    circle(d=hole_diameter);
+                    circle(d=wire_diameter);
                 }
             }
         }

--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -6,6 +6,7 @@ switch_width = 135.0;
 switch_depth = 135.0;
 switch_height = 28.30;
 
+case_thickness = 6; // Thickness of case walls
 
 front_wire_holes = false; // [true:Show front wire holes, false:Hide front wire holes]
 air_holes = true; // [true:Show air holes, false:Hide air holes]
@@ -20,7 +21,7 @@ height = 44.45 * rack_height;
 module switch_mount(switch_width, switch_height, switch_depth) {
     //6 inch racks (mounts=152.4mm; rails=15.875mm; usable space=120.65mm)
     //10 inch racks (mounts=254.0mm; rails=15.875mm; usable space=221.5mm)
-    chassis_width = min(switch_width + 12, (rack_width == 152.4) ? 120.65 : 221.5);
+    chassis_width = min(switch_width + (2 * case_thickness), (rack_width == 152.4) ? 120.65 : 221.5);
     front_thickness = 3.0;
     corner_radius = 4.0;
     chassis_edge_radius = 2.0;
@@ -75,7 +76,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
     // Create the main body as a separate module
     module main_body() {
         side_margin = (rack_width - chassis_width) / 2;
-        chassis_height = switch_height + 12;
+        chassis_height = switch_height + (2 * case_thickness);
         union() {
             // Front panel
             linear_extrude(height = front_thickness) {
@@ -185,7 +186,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         
         // Zip tie indents (top and bottom)
         x_pos = (rack_width - switch_width)/2;
-        chassis_height = switch_height + 12;
+        chassis_height = switch_height + (2 * case_thickness);
         // Bottom indent
         translate([x_pos, (height - chassis_height)/2, switch_depth]) {
             cube([switch_width, zip_tie_indent_depth, zip_tie_cutout_depth]);
@@ -247,7 +248,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         
         // SIDE FACE HOLES (X-axis through left and right sides)
         // Calculate chassis dimensions
-        chassis_width = min(switch_width + 12, (rack_width == 152.4) ? 120.65 : 221.5);
+        chassis_width = min(switch_width + (2 * case_thickness), (rack_width == 152.4) ? 120.65 : 221.5);
         side_margin = (rack_width - chassis_width) / 2;
         
         // Calculate available space within switch height

--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -8,6 +8,7 @@ switch_height = 28.30;
 
 case_thickness = 6; // Thickness of case walls
 wire_diameter = 7; // Diameter of power wire holes
+zip_tie_hole_width = 1.5; // Width of zip tie slots
 
 front_wire_holes = false; // [true:Show front wire holes, false:Hide front wire holes]
 air_holes = true; // [true:Show air holes, false:Hide air holes]
@@ -29,7 +30,6 @@ module switch_mount(switch_width, switch_height, switch_depth) {
     tolerance = 0.42;
 
     zip_tie_hole_count = 8;
-    zip_tie_hole_width = 1.5;
     zip_tie_hole_length = 5;
     zip_tie_indent_depth = 2;
     zip_tie_cutout_depth = 7;

--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -228,7 +228,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         if (x_cols > 0 && z_rows > 0) {
             for (i = [0:x_cols-1]) {
                 for (j = [0:z_rows-1]) {
-                    // Stagger every other COLUMN (i) instead of row (j) for vertical honeycomb pattern
+                    // Stagger every other COLUMN (i) for vertical honeycomb pattern
                     z_offset = (i % 2 == 1) ? spacing_z/2 : 0;
                     x_pos = x_start + i * spacing_x;
                     z_pos = z_start + j * spacing_z + z_offset;
@@ -237,7 +237,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
                     if (z_pos + hole_d/2 <= cutout_center_z + switch_depth/2 - margin && 
                         z_pos - hole_d/2 >= cutout_center_z - switch_depth/2 + margin) {
                         translate([x_pos, height, z_pos]) {
-                            rotate([90, 0, 0]) {
+                            rotate([90, 30, 0]) {
                                 cylinder(h = height, d = hole_d, $fn = 6);
                             }
                         }
@@ -276,7 +276,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
                 
                 for (i = [0:y_cols-1]) {
                     for (j = [0:z_rows_side-1]) {
-                        // Stagger every other COLUMN (i) instead of row (j) for vertical honeycomb pattern
+                        // Stagger every other COLUMN (i) for vertical honeycomb pattern
                         z_offset = (i % 2 == 1) ? spacing_z/2 : 0;
                         y_pos = y_start + i * spacing_x;
                         z_pos = z_start_side + j * spacing_z + z_offset;
@@ -286,9 +286,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
                             z_pos - hole_d/2 >= cutout_center_z - switch_depth/2 + margin) {
                             translate([side_x, y_pos, z_pos]) {
                                 rotate([0, 90, 0]) {
-                                    rotate([0, 0, 90]) {  // Rotate hexagon 90 degrees to match front/back orientation
-                                        cylinder(h = chassis_width, d = hole_d, $fn = 6);
-                                    }
+                                    cylinder(h = chassis_width, d = hole_d, $fn = 6);
                                 }
                             }
                         }


### PR DESCRIPTION
Rotates the holes so there's no bridging when 3d printing, and makes sure the hex grid still works.