### PR TITLE
Add Component Offset

### DIFF
--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -10,10 +10,9 @@ component_height = 28.30;
 // ========================================
 /* [Keystones] */
 // Add keystone jacks to the front panel
-keystones = false; 
-keystone_left = true;
-keystone_right = true;
-// [true: Place keystone jacks, false: Remove keystone jacks]
+keystones = false;    // [true: Place keystone jacks, false: Remove keystone jacks]
+keystone_left = true;  // [true: Place keystone jack on the left, false: Remove left keystone jack]
+keystone_right = true; // [true: Place keystone jack on the right, false: Remove right keystone jacks]
 
 // ========================================
 /* [Holes] */
@@ -135,7 +134,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             // add offset
             
             translate([
-                (rack_width - (cutout_w - 2*lip_thickness )) / 2,
+                (rack_width - (cutout_w - 2*lip_thickness)) / 2,
                 (height - (cutout_h - 2*lip_thickness)) / 2,
                 -tolerance
             ]) {
@@ -470,10 +469,10 @@ module switch_mount(switch_width, switch_height, switch_depth) {
                 }
                 
                 if (keystones) {
-                    if (keystone_left) {      
+                    if (keystone_left) {      //Cutout for left Keystone
                         keystone_front_cutout();
                     }
-                    if (keystone_right){
+                    if (keystone_right){     //Cutout for Right Keystone
                         translate([rack_width, 0, 0]) mirror([1, 0, 0])
                         keystone_front_cutout();
                     }
@@ -482,11 +481,10 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         }
        if (keystones) {
            //rotate([90,0,0]) maps keystone Y→rack Z (depth), keystone Z→rack -Y (compensated by +keystone_outer_height in translate)
-           if (keystone_left){
+           if (keystone_left){    //Make left Keystone
             translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
            }
-           
-          if (keystone_right){
+          if (keystone_right){   //Make right Keystone
             translate([rack_width, 0, 0]) mirror([1, 0, 0])
             translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
           }

--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -10,7 +10,10 @@ component_height = 28.30;
 // ========================================
 /* [Keystones] */
 // Add keystone jacks to the front panel
-keystones = false; // [true: Place keystone jacks, false: Remove keystone jacks]
+keystones = false; 
+keystone_left = true;
+keystone_right = true;
+// [true: Place keystone jacks, false: Remove keystone jacks]
 
 // ========================================
 /* [Holes] */
@@ -128,8 +131,11 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             lip_thickness = 1.2;
             lip_depth = 0.60;
             // Main cutout minus lip (centered)
+            
+            // add offset
+            
             translate([
-                (rack_width - (cutout_w - 2*lip_thickness)) / 2,
+                (rack_width - (cutout_w - 2*lip_thickness )) / 2,
                 (height - (cutout_h - 2*lip_thickness)) / 2,
                 -tolerance
             ]) {
@@ -462,17 +468,28 @@ module switch_mount(switch_width, switch_height, switch_depth) {
                 if (air_holes) {
                     air_holes();
                 }
+                
                 if (keystones) {
-                    keystone_front_cutout();
-                    translate([rack_width, 0, 0]) mirror([1, 0, 0]) keystone_front_cutout();
+                    if (keystone_left) {      
+                        keystone_front_cutout();
+                    }
+                    if (keystone_right){
+                        translate([rack_width, 0, 0]) mirror([1, 0, 0])
+                        keystone_front_cutout();
+                    }
                 }
             }
         }
-        if (keystones) {
-            // rotate([90,0,0]) maps keystone Y→rack Z (depth), keystone Z→rack -Y (compensated by +keystone_outer_height in translate)
+       if (keystones) {
+           //rotate([90,0,0]) maps keystone Y→rack Z (depth), keystone Z→rack -Y (compensated by +keystone_outer_height in translate)
+           if (keystone_left){
             translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
+           }
+           
+          if (keystone_right){
             translate([rack_width, 0, 0]) mirror([1, 0, 0])
-                translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
+            translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
+          }
         }
     }
 }

--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -2,10 +2,10 @@ rack_width = 254.0; // [ 254.0:10 inch, 152.4:6 inch]
 // Height of the rack in U units, can be a fraction for partial U (e.g. 1.5 for 1U plus half of the next U)
 rack_height = 1.0; // [0.5:0.5:5]
 
-
 component_width = 110.0;
 component_depth = 122.0;
 component_height = 28.30;
+component_offset = 0;  // [-100:0.1:100]
 
 // ========================================
 /* [Keystones] */
@@ -110,7 +110,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
     
     // Create the main body as a separate module
     module main_body() {
-        side_margin = (rack_width - chassis_width) / 2;
+        side_margin = ((rack_width - chassis_width) / 2) + component_offset;
         chassis_height = min(switch_height + (2 * case_thickness), height);
         union() {
             // Front panel
@@ -130,11 +130,8 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             lip_thickness = 1.2;
             lip_depth = 0.60;
             // Main cutout minus lip (centered)
-            
-            // add offset
-            
             translate([
-                (rack_width - (cutout_w - 2*lip_thickness)) / 2,
+                ((rack_width - (cutout_w - 2*lip_thickness)) / 2) + component_offset,
                 (height - (cutout_h - 2*lip_thickness)) / 2,
                 -tolerance
             ]) {
@@ -142,7 +139,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             }
             // Switch cutout above the lip (centered)
             translate([
-                (rack_width - cutout_w) / 2,
+                ((rack_width - cutout_w) / 2) + component_offset,
                 (height - cutout_h) / 2,
                 lip_depth
             ]) {
@@ -153,7 +150,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             z_start = front_plate_hole ? -tolerance : front_plate_thickness;
             z_depth = front_plate_hole ? chassis_depth_main + 2*tolerance : chassis_depth_main - front_plate_thickness + tolerance;
             translate([
-                (rack_width - cutout_w) / 2,
+                ((rack_width - cutout_w) / 2) + component_offset,
                 (height - cutout_h) / 2,
                 z_start
             ]) {
@@ -210,8 +207,8 @@ module switch_mount(switch_width, switch_height, switch_depth) {
     // Power wire cutouts: configurable diameter holes at top and bottom rack hole positions
     module power_wire_cutouts() {
         hole_spacing_x = switch_width; // match rack holes
-        hole_left_x = (rack_width - hole_spacing_x) / 2 - (wire_diameter /5);
-        hole_right_x = (rack_width + hole_spacing_x) / 2 + (wire_diameter /5);
+        hole_left_x = (rack_width - hole_spacing_x) / 2 - (wire_diameter /5) + component_offset;
+        hole_right_x = (rack_width + hole_spacing_x) / 2 + (wire_diameter /5) + component_offset;
         // Midplane of switch opening
         mid_y = (height - switch_height) / 2 + switch_height / 2;
         for (side_x = [hole_left_x, hole_right_x]) {
@@ -228,14 +225,14 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         // Zip tie holes
         zip_z = switch_depth + solid_z_offset;
         for (i = [0:zip_tie_hole_count-1]) {
-            x_pos = (rack_width - switch_width)/2 + (switch_width/(zip_tie_hole_count+1)) * (i+1);
+            x_pos = (rack_width - switch_width)/2 + component_offset + (switch_width/(zip_tie_hole_count+1)) * (i+1);
             translate([x_pos, 0, zip_z]) {
                 cube([zip_tie_hole_width, height, zip_tie_hole_length]);
             }
         }
 
         // Zip tie indents (top and bottom)
-        x_pos = (rack_width - switch_width)/2;
+        x_pos = ((rack_width - switch_width)/2) + component_offset;
         chassis_height = min(switch_height + (2 * case_thickness), height);
         // Bottom indent
         translate([x_pos, (height - chassis_height)/2, zip_z]) {
@@ -273,7 +270,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         actual_grid_depth = (z_rows - 1) * spacing_z;
 
         // Center the grid within the switch cutout area
-        cutout_center_x = rack_width / 2;
+        cutout_center_x = (rack_width / 2) + component_offset;
         cutout_center_z = front_plate_thickness + switch_depth / 2;
 
         x_start = cutout_center_x - actual_grid_width / 2;


### PR DESCRIPTION
- Add component_offset varible allowing user to move the component cutout left or right.

This simple added feature paired with the independent ketstones allows users to add one keystone next to a componet that would normally be to big to fit.


<img width="1076" height="712" alt="Before" src="https://github.com/user-attachments/assets/b64f6e66-d515-40ed-a962-31c933ecf990" />
<img width="966" height="603" alt="After" src="https://github.com/user-attachments/assets/c6618ec4-47cb-4db8-8450-1cae5e24a628" />
