### PR TITLE
New features - keystones independent, wire holes independent, component offset(2nd try)

### DIFF
--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -18,6 +18,8 @@ keystone_right = true; // [true: Place keystone jack on the right, false: Remove
 /* [Holes] */
 // Adds small cutout a USB or Power cable could be routed through to the front
 front_wire_holes = false; // [true:Show front wire holes, false:Hide front wire holes]
+front_wire_hole_left = true; // [true:Show left wire hole, false:Hide left wire hole]
+front_wire_hole_right = true; // [true:Show right wire hole, false:Hide right wire hole]
 // Diameter of wire to route through front_wire_holes.
 wire_diameter = 7; // Diameter of power wire holes
 // Adds hexagon air cutouts to reduce material and improve cooling.
@@ -206,20 +208,21 @@ module switch_mount(switch_width, switch_height, switch_depth) {
 
     // Power wire cutouts: configurable diameter holes at top and bottom rack hole positions
     module power_wire_cutouts() {
+        mid_y = (height - switch_height) / 2 + switch_height / 2; // Midplane of switch opening
         hole_spacing_x = switch_width; // match rack holes
-        hole_left_x = (rack_width - hole_spacing_x) / 2 - (wire_diameter /5) + component_offset;
-        hole_right_x = (rack_width + hole_spacing_x) / 2 + (wire_diameter /5) + component_offset;
-        // Midplane of switch opening
-        mid_y = (height - switch_height) / 2 + switch_height / 2;
-        for (side_x = [hole_left_x, hole_right_x]) {
-            translate([side_x, mid_y, 0]) {
-                linear_extrude(height = chassis_depth_main) {
-                    circle(d=wire_diameter);
-                }
+        if (front_wire_hole_left){   //make left hole
+            hole_left_x = (rack_width - hole_spacing_x) / 2 - (wire_diameter /5) + component_offset;
+            translate([hole_left_x, mid_y, 0]) {
+                linear_extrude(height = chassis_depth_main) {circle(d=wire_diameter);}
+            }
+        }
+        if (front_wire_hole_right){   //make right hole
+            hole_right_x = (rack_width + hole_spacing_x) / 2 + (wire_diameter /5) + component_offset;
+            translate([hole_right_x, mid_y, 0]) {
+                linear_extrude(height = chassis_depth_main) {circle(d=wire_diameter);}
             }
         }
     }
-    
     // Create zip tie holes and indents
     module zip_tie_features() {
         // Zip tie holes

--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -10,10 +10,9 @@ component_height = 28.30;
 // ========================================
 /* [Keystones] */
 // Add keystone jacks to the front panel
-keystones = false; 
-keystone_left = true;
-keystone_right = true;
-// [true: Place keystone jacks, false: Remove keystone jacks]
+keystones = false;    // [true: Place keystone jacks, false: Remove keystone jacks]
+keystone_left = true;  // [true: Place keystone jack on the left, false: Remove left keystone jack]
+keystone_right = true; // [true: Place keystone jack on the right, false: Remove right keystone jacks]
 
 // ========================================
 /* [Holes] */
@@ -135,7 +134,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             // add offset
             
             translate([
-                (rack_width - (cutout_w - 2*lip_thickness )) / 2,
+                (rack_width - (cutout_w - 2*lip_thickness)) / 2,
                 (height - (cutout_h - 2*lip_thickness)) / 2,
                 -tolerance
             ]) {
@@ -470,10 +469,10 @@ module switch_mount(switch_width, switch_height, switch_depth) {
                 }
                 
                 if (keystones) {
-                    if (keystone_left) {      
+                    if (keystone_left) {      //Cutout for left Keystone
                         keystone_front_cutout();
                     }
-                    if (keystone_right){
+                    if (keystone_right){     //Cutout for Right Keystone
                         translate([rack_width, 0, 0]) mirror([1, 0, 0])
                         keystone_front_cutout();
                     }
@@ -482,11 +481,10 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         }
        if (keystones) {
            //rotate([90,0,0]) maps keystone Y→rack Z (depth), keystone Z→rack -Y (compensated by +keystone_outer_height in translate)
-           if (keystone_left){
+           if (keystone_left){    //Make left Keystone
             translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
            }
-           
-          if (keystone_right){
+          if (keystone_right){   //Make right Keystone
             translate([rack_width, 0, 0]) mirror([1, 0, 0])
             translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
           }

--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -10,7 +10,10 @@ component_height = 28.30;
 // ========================================
 /* [Keystones] */
 // Add keystone jacks to the front panel
-keystones = false; // [true: Place keystone jacks, false: Remove keystone jacks]
+keystones = false; 
+keystone_left = true;
+keystone_right = true;
+// [true: Place keystone jacks, false: Remove keystone jacks]
 
 // ========================================
 /* [Holes] */
@@ -128,8 +131,11 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             lip_thickness = 1.2;
             lip_depth = 0.60;
             // Main cutout minus lip (centered)
+            
+            // add offset
+            
             translate([
-                (rack_width - (cutout_w - 2*lip_thickness)) / 2,
+                (rack_width - (cutout_w - 2*lip_thickness )) / 2,
                 (height - (cutout_h - 2*lip_thickness)) / 2,
                 -tolerance
             ]) {
@@ -462,17 +468,28 @@ module switch_mount(switch_width, switch_height, switch_depth) {
                 if (air_holes) {
                     air_holes();
                 }
+                
                 if (keystones) {
-                    keystone_front_cutout();
-                    translate([rack_width, 0, 0]) mirror([1, 0, 0]) keystone_front_cutout();
+                    if (keystone_left) {      
+                        keystone_front_cutout();
+                    }
+                    if (keystone_right){
+                        translate([rack_width, 0, 0]) mirror([1, 0, 0])
+                        keystone_front_cutout();
+                    }
                 }
             }
         }
-        if (keystones) {
-            // rotate([90,0,0]) maps keystone Y→rack Z (depth), keystone Z→rack -Y (compensated by +keystone_outer_height in translate)
+       if (keystones) {
+           //rotate([90,0,0]) maps keystone Y→rack Z (depth), keystone Z→rack -Y (compensated by +keystone_outer_height in translate)
+           if (keystone_left){
             translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
+           }
+           
+          if (keystone_right){
             translate([rack_width, 0, 0]) mirror([1, 0, 0])
-                translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
+            translate([keystone_tx, keystone_ty + keystone_outer_height, 0]) rotate([90,0,0]) keystone();
+          }
         }
     }
 }

--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -257,7 +257,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         // Chassis dimensions used by both hole sections
         chassis_height = min(switch_height + (2 * case_thickness), height);
         chassis_width = min(switch_width + (2 * case_thickness), (rack_width == 152.4) ? 120.65 : 221.5);
-        side_margin = (rack_width - chassis_width) / 2;
+        side_margin = ((rack_width - chassis_width) / 2) + component_offset;
 
         // TOP/BOTTOM FACE HOLES (Y-axis, penetrating top and bottom chassis walls)
         // Calculate available space for holes within switch dimensions

--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -2,10 +2,10 @@ rack_width = 254.0; // [ 254.0:10 inch, 152.4:6 inch]
 // Height of the rack in U units, can be a fraction for partial U (e.g. 1.5 for 1U plus half of the next U)
 rack_height = 1.0; // [0.5:0.5:5]
 
-
 component_width = 110.0;
 component_depth = 122.0;
 component_height = 28.30;
+component_offset = 0;  // [-100:0.1:100]
 
 // ========================================
 /* [Keystones] */
@@ -110,7 +110,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
     
     // Create the main body as a separate module
     module main_body() {
-        side_margin = (rack_width - chassis_width) / 2;
+        side_margin = ((rack_width - chassis_width) / 2) + component_offset;
         chassis_height = min(switch_height + (2 * case_thickness), height);
         union() {
             // Front panel
@@ -130,11 +130,8 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             lip_thickness = 1.2;
             lip_depth = 0.60;
             // Main cutout minus lip (centered)
-            
-            // add offset
-            
             translate([
-                (rack_width - (cutout_w - 2*lip_thickness)) / 2,
+                ((rack_width - (cutout_w - 2*lip_thickness)) / 2) + component_offset,
                 (height - (cutout_h - 2*lip_thickness)) / 2,
                 -tolerance
             ]) {
@@ -142,7 +139,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             }
             // Switch cutout above the lip (centered)
             translate([
-                (rack_width - cutout_w) / 2,
+                ((rack_width - cutout_w) / 2) + component_offset,
                 (height - cutout_h) / 2,
                 lip_depth
             ]) {
@@ -153,7 +150,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
             z_start = front_plate_hole ? -tolerance : front_plate_thickness;
             z_depth = front_plate_hole ? chassis_depth_main + 2*tolerance : chassis_depth_main - front_plate_thickness + tolerance;
             translate([
-                (rack_width - cutout_w) / 2,
+                ((rack_width - cutout_w) / 2) + component_offset,
                 (height - cutout_h) / 2,
                 z_start
             ]) {
@@ -210,8 +207,8 @@ module switch_mount(switch_width, switch_height, switch_depth) {
     // Power wire cutouts: configurable diameter holes at top and bottom rack hole positions
     module power_wire_cutouts() {
         hole_spacing_x = switch_width; // match rack holes
-        hole_left_x = (rack_width - hole_spacing_x) / 2 - (wire_diameter /5);
-        hole_right_x = (rack_width + hole_spacing_x) / 2 + (wire_diameter /5);
+        hole_left_x = (rack_width - hole_spacing_x) / 2 - (wire_diameter /5) + component_offset;
+        hole_right_x = (rack_width + hole_spacing_x) / 2 + (wire_diameter /5) + component_offset;
         // Midplane of switch opening
         mid_y = (height - switch_height) / 2 + switch_height / 2;
         for (side_x = [hole_left_x, hole_right_x]) {
@@ -228,14 +225,14 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         // Zip tie holes
         zip_z = switch_depth + solid_z_offset;
         for (i = [0:zip_tie_hole_count-1]) {
-            x_pos = (rack_width - switch_width)/2 + (switch_width/(zip_tie_hole_count+1)) * (i+1);
+            x_pos = (rack_width - switch_width)/2 + component_offset + (switch_width/(zip_tie_hole_count+1)) * (i+1);
             translate([x_pos, 0, zip_z]) {
                 cube([zip_tie_hole_width, height, zip_tie_hole_length]);
             }
         }
 
         // Zip tie indents (top and bottom)
-        x_pos = (rack_width - switch_width)/2;
+        x_pos = ((rack_width - switch_width)/2) + component_offset;
         chassis_height = min(switch_height + (2 * case_thickness), height);
         // Bottom indent
         translate([x_pos, (height - chassis_height)/2, zip_z]) {
@@ -273,7 +270,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
         actual_grid_depth = (z_rows - 1) * spacing_z;
 
         // Center the grid within the switch cutout area
-        cutout_center_x = rack_width / 2;
+        cutout_center_x = (rack_width / 2) + component_offset;
         cutout_center_z = front_plate_thickness + switch_depth / 2;
 
         x_start = cutout_center_x - actual_grid_width / 2;

--- a/KeystoneJack.scad
+++ b/KeystoneJack.scad
@@ -33,11 +33,11 @@ module keystone(
                 // Make solid cube
                 cube([jack_width+wall,jack_depth,jack_height+wall]);
             // Cut out the front hole
-            translate([(jack_width+wall-front_hole_width)/2,0,front_hole_z_offset])
+            translate([(jack_width+wall-front_hole_width)/2,-e,front_hole_z_offset])
                 color("blue")
                 cube([front_hole_width,jack_depth+wall,front_hole_height]);
             // Cut out the back hole. It should be extruded to front_large_catch_depth
-            translate([(jack_width+wall-front_hole_width)/2,front_large_catch_depth,back_hole_z_offset])
+            translate([(jack_width+wall-front_hole_width)/2,front_large_catch_depth - e,back_hole_z_offset ])
                 color("red")
                 cube([front_hole_width,jack_depth+wall-front_large_catch_depth,back_hole_height]);
 


### PR DESCRIPTION
- Add feature to allow users to remove or add the left and right keystones independently.
- Add feature that lets users remove or add wire holes independently.
- Add component_offset variable allowing user to move the component cutout left or right.
The component offset paired with the keystones independent feature will allow the user to put one keystone next to a bigger component that would normally not fit with two on each side. 