### PR TITLE
Module air_holes condensed

### DIFF
--- a/10InchRackGenerator.scad
+++ b/10InchRackGenerator.scad
@@ -1,3 +1,6 @@
+include <BOSL2/std.scad>
+include <BOSL2/walls.scad>
+
 rack_width = 254.0; // [ 254.0:10 inch, 152.4:6 inch]
 // Height of the rack in U units, can be a fraction for partial U (e.g. 1.5 for 1U plus half of the next U)
 rack_height = 1.0; // [0.5:0.5:5]
@@ -244,110 +247,29 @@ module switch_mount(switch_width, switch_height, switch_depth) {
 
     // Simplified air holes with staggered honeycomb pattern on all faces
     module air_holes() {
-        hole_d = 16;
-        spacing_x = 15;  // Horizontal spacing (X and Y directions)
-        spacing_z = 17;  // Vertical spacing (Z direction) - tighter to match visual density
-        margin = 3; // Keep holes away from edges
-
-        // Chassis dimensions used by both hole sections
-        chassis_height = min(switch_height + (2 * case_thickness), height);
-        chassis_width = min(switch_width + (2 * case_thickness), (rack_width == 152.4) ? 120.65 : 221.5);
-        side_margin = (rack_width - chassis_width) / 2;
-
-        // TOP/BOTTOM FACE HOLES (Y-axis, penetrating top and bottom chassis walls)
-        // Calculate available space for holes within switch dimensions
-        available_width = switch_width - (2 * margin);
-        available_depth = switch_depth - (2 * margin);
-
-        // Calculate number of holes that fit
-        x_cols = floor(available_width / spacing_x);
-        z_rows = floor(available_depth / spacing_z);
-
-        // Calculate actual grid size for centering
-        actual_grid_width = (x_cols - 1) * spacing_x;
-        actual_grid_depth = (z_rows - 1) * spacing_z;
-
-        // Center the grid within the switch cutout area
-        cutout_center_x = rack_width / 2;
-        cutout_center_z = front_plate_thickness + switch_depth / 2;
-
-        x_start = cutout_center_x - actual_grid_width / 2;
-        z_start = cutout_center_z - actual_grid_depth / 2;
-
-        // Cylinder must span the full chassis height in Y, including when chassis_height > height
-        // (chassis body is centered in height, so it can protrude above/below the front panel bounds)
-        y_hole_top = (height + chassis_height) / 2 + 1;
-        y_hole_h = chassis_height + 2;
-
-        // Create top/bottom face holes with VERTICAL staggered pattern
-        if (x_cols > 0 && z_rows > 0) {
-            for (i = [0:x_cols-1]) {
-                for (j = [0:z_rows-1]) {
-                    // Stagger every other COLUMN (i) instead of row (j) for vertical honeycomb pattern
-                    z_offset = (i % 2 == 1) ? spacing_z/2 : 0;
-                    x_pos = x_start + i * spacing_x;
-                    z_pos = z_start + j * spacing_z + z_offset;
-
-                    // Only place hole if it fits within bounds after staggering
-                    if (z_pos + hole_d/2 <= cutout_center_z + switch_depth/2 - margin &&
-                        z_pos - hole_d/2 >= cutout_center_z - switch_depth/2 + margin) {
-                        translate([x_pos, y_hole_top, z_pos]) {
-                            rotate([90, 0, 0]) {
-                                cylinder(h = y_hole_h, d = hole_d, $fn = 6);
-                            }
-                        }
+        hex_strut = 4; 
+        hex_spacing = 15;
+        hex_bottom_frame = 10; 
+                
+        test_hex_fit_Y = (component_height + case_thickness*2) - ( hex_spacing + hex_bottom_frame*2);
+        test_hex_fit_x = (component_width + case_thickness*2) - ( hex_spacing + hex_bottom_frame*2);
+        
+        if(air_holes){
+            translate([rack_width/2, height/2, component_depth/2]){
+                if(test_hex_fit_x >= 0){
+                    difference(){         
+                        cuboid([component_width + case_thickness*2+.1, component_height + case_thickness*2+.1, component_depth],rounding=0,edges=["Z"]);
+                        hex_panel([component_width + case_thickness*2-.1, component_depth, component_height + case_thickness*2-.1], hex_strut, hex_spacing, frame=hex_bottom_frame, orient=FRONT); 
+                    }
+                }
+                 if (test_hex_fit_Y >= 0){
+                    difference(){            
+                        cuboid([component_width+ case_thickness*2+.1, component_height + case_thickness*2+.1, component_depth],rounding=0,edges=["Z"]);
+                        hex_panel([ component_depth, component_height + case_thickness*2-.1, component_width+ case_thickness*2-.1], hex_strut, hex_spacing, frame=hex_bottom_frame, orient=LEFT); 
                     }
                 }
             }
-        }
-
-        // SIDE FACE HOLES (X-axis through left and right walls)
-
-        // Calculate available space within chassis height (includes case walls above/below switch)
-        available_height = chassis_height - (2 * margin);
-        available_side_depth = switch_depth - (2 * margin);
-
-        // Calculate number of holes that fit on sides
-        y_cols = floor(available_height / spacing_x);  // Use spacing_x for Y direction
-        z_rows_side = floor(available_side_depth / spacing_z);
-
-        // Calculate actual grid size for sides
-        actual_grid_height = (y_cols - 1) * spacing_x;
-        actual_grid_depth_side = (z_rows_side - 1) * spacing_z;
-
-        // Center the grid within the chassis height (Y) and switch depth (Z)
-        cutout_center_y = height / 2;  // Chassis is centered in the 1U height
-
-        y_start = cutout_center_y - actual_grid_height / 2;
-        z_start_side = cutout_center_z - actual_grid_depth_side / 2;
-
-        // Each cylinder runs from 1mm outside the left wall all the way through to 1mm outside
-        // the right wall. Using a single cylinder per position avoids the right-side cylinder
-        // going in the wrong direction (away from the chassis).
-        if (y_cols > 0 && z_rows_side > 0) {
-            for (i = [0:y_cols-1]) {
-                for (j = [0:z_rows_side-1]) {
-                    // Stagger every other COLUMN (i) instead of row (j) for vertical honeycomb pattern
-                    z_offset = (i % 2 == 1) ? spacing_z/2 : 0;
-                    y_pos = y_start + i * spacing_x;
-                    z_pos = z_start_side + j * spacing_z + z_offset;
-
-                    // Only place hole if it fits within bounds after staggering
-                    if (y_pos + hole_d/2 <= cutout_center_y + chassis_height/2 - margin &&
-                        y_pos - hole_d/2 >= cutout_center_y - chassis_height/2 + margin &&
-                        z_pos + hole_d/2 <= cutout_center_z + switch_depth/2 - margin &&
-                        z_pos - hole_d/2 >= cutout_center_z - switch_depth/2 + margin) {
-                        translate([side_margin - 1, y_pos, z_pos]) {
-                            rotate([0, 90, 0]) {
-                                rotate([0, 0, 90]) {  // Rotate hexagon 90 degrees to match front/back orientation
-                                    cylinder(h = chassis_width + 2, d = hole_d, $fn = 6);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        }                        
     }
 
     // Complete keystone with embossed triangle
@@ -459,9 +381,7 @@ module switch_mount(switch_width, switch_height, switch_depth) {
                 if (front_wire_holes) {
                     power_wire_cutouts();
                 }
-                if (air_holes) {
                     air_holes();
-                }
                 if (keystones) {
                     keystone_front_cutout();
                     translate([rack_width, 0, 0]) mirror([1, 0, 0]) keystone_front_cutout();


### PR DESCRIPTION
air_holes module reworte using wall.scad
- Condensed from 104 to 23 lines of code
- Rotates the hexes so the point is facing to the buildplate
- fixs issue with side wall hexs cutting into the top and bottom walls